### PR TITLE
Implement two way serialization

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
   "plugins": ["@typescript-eslint"],
   "root": true,
   "rules": {
+    "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/no-unused-vars": [
       "error",
       {

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -3,7 +3,7 @@
 export default {
   collectCoverage: true,
   coverageDirectory: "coverage",
-  coverageProvider: "v8",
+  coverageProvider: "babel",
   coverageThreshold: {
     global: {
       branches: 100,

--- a/src/Codec.ts
+++ b/src/Codec.ts
@@ -7,7 +7,8 @@ export class Codec<I, O = I> {
   readonly Output!: O
 
   constructor(
-    readonly validate: (value: unknown, ctx: ValidationContext) => Result<O>
+    readonly validate: (value: unknown, ctx: ValidationContext) => Result<O>,
+    readonly encode: (value: O) => I
   ) {
     this.parse = this.parse.bind(this)
     this.unsafeParse = this.unsafeParse.bind(this)
@@ -24,5 +25,5 @@ export class Codec<I, O = I> {
   }
 }
 
-export type Input<C extends Codec<unknown>> = C["Input"]
-export type Output<C extends Codec<unknown>> = C["Output"]
+export type Input<C extends Codec<any>> = C["Input"]
+export type Output<C extends Codec<any>> = C["Output"]

--- a/src/SimpleCodec.ts
+++ b/src/SimpleCodec.ts
@@ -1,0 +1,12 @@
+import { Codec } from "./Codec.js"
+import { ValidationContext } from "./ValidationContext.js"
+import { Result } from "./Result.js"
+import { identity } from "./utils.js"
+
+export class SimpleCodec<T> extends Codec<T, T> {
+  constructor(
+    readonly validate: (value: unknown, ctx: ValidationContext) => Result<T>
+  ) {
+    super(validate, identity)
+  }
+}

--- a/src/codecs/array.ts
+++ b/src/codecs/array.ts
@@ -1,36 +1,36 @@
 import { Codec, Input, Output } from "../Codec.js"
 
-class ArrayCodec<C extends Codec<unknown>> extends Codec<
-  Input<C>[],
-  Output<C>[]
-> {
+class ArrayCodec<C extends Codec<any>> extends Codec<Input<C>[], Output<C>[]> {
   readonly tag = "array"
 
   constructor(readonly values: C) {
-    super((value, ctx) => {
-      if (!Array.isArray(value))
-        return ctx.failure({
-          code: "invalid_type",
-          message: "Expected value to be an array",
-          value,
-        })
+    super(
+      (value, ctx) => {
+        if (!Array.isArray(value))
+          return ctx.failure({
+            code: "invalid_type",
+            message: "Expected value to be an array",
+            value,
+          })
 
-      let ok = true
-      const array: Output<C>[] = []
-      const path = ctx.path
+        let ok = true
+        const array: Output<C>[] = []
+        const path = ctx.path
 
-      for (let i = 0; i < value.length; i++) {
-        ctx.setPath(path ? `${path}[${i}]` : String(i))
-        const element = value[i]
-        const result = values.validate(element, ctx)
-        if (!result.ok) ok = false
-        else if (ok) array.push(result.value)
-      }
+        for (let i = 0; i < value.length; i++) {
+          ctx.setPath(path ? `${path}[${i}]` : String(i))
+          const element = value[i]
+          const result = values.validate(element, ctx)
+          if (!result.ok) ok = false
+          else if (ok) array.push(result.value)
+        }
 
-      return ok ? ctx.success(array) : ctx.failures()
-    })
+        return ok ? ctx.success(array) : ctx.failures()
+      },
+      (array) => array.map((value) => values.encode(value))
+    )
   }
 }
 
-export const array = <C extends Codec<unknown>>(codec: C): ArrayCodec<C> =>
+export const array = <C extends Codec<any>>(codec: C): ArrayCodec<C> =>
   new ArrayCodec(codec)

--- a/src/codecs/boolean.ts
+++ b/src/codecs/boolean.ts
@@ -1,6 +1,6 @@
-import { Codec } from "../Codec.js"
+import { SimpleCodec } from "../SimpleCodec.js"
 
-class BooleanCodec extends Codec<boolean> {
+class BooleanCodec extends SimpleCodec<boolean> {
   readonly tag = "boolean"
 
   constructor() {

--- a/src/codecs/number.ts
+++ b/src/codecs/number.ts
@@ -1,6 +1,6 @@
-import { Codec } from "../Codec.js"
+import { SimpleCodec } from "../SimpleCodec.js"
 
-class NumberCodec extends Codec<number> {
+class NumberCodec extends SimpleCodec<number> {
   readonly tag = "number"
 
   constructor() {

--- a/src/codecs/object.ts
+++ b/src/codecs/object.ts
@@ -1,45 +1,59 @@
 import { Codec, Input, Output } from "../Codec.js"
 import { hasOwnProperty } from "../utils.js"
 
-class ObjectCodec<T extends Record<string, Codec<unknown>>> extends Codec<
+class ObjectCodec<T extends Record<string, Codec<any>>> extends Codec<
   { [K in keyof T]: Input<T[K]> },
   { [K in keyof T]: Output<T[K]> }
 > {
   constructor(readonly props: T) {
     const keys = Object.keys(props)
 
-    super((value, ctx) => {
-      if (value == null || typeof value !== "object" || Array.isArray(value))
-        return ctx.failure({
-          code: "invalid_type",
-          message: "Expected value to be an object",
-          value,
-        })
+    super(
+      (value, ctx) => {
+        if (value == null || typeof value !== "object" || Array.isArray(value))
+          return ctx.failure({
+            code: "invalid_type",
+            message: "Expected value to be an object",
+            value,
+          })
 
-      let ok = true
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const object = {} as any
-      const path = ctx.path
+        let ok = true
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const object = {} as any
+        const path = ctx.path
 
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i]
-        const codec = props[key]
-        ctx.setPath(path ? `${path}.${key}` : key)
+        for (let i = 0; i < keys.length; i++) {
+          const key = keys[i]
+          const codec = props[key]
+          ctx.setPath(path ? `${path}.${key}` : key)
 
-        const property = hasOwnProperty(value, key) ? value[key] : undefined
+          const property = hasOwnProperty(value, key) ? value[key] : undefined
 
-        const result = codec.validate(property, ctx)
-        if (!result.ok) ok = false
-        else if (ok && result.value !== undefined) object[key] = result.value
+          const result = codec.validate(property, ctx)
+          if (!result.ok) ok = false
+          else if (ok && result.value !== undefined) object[key] = result.value
+        }
+
+        ctx.setPath(path)
+
+        return ok ? ctx.success(object) : ctx.failures()
+      },
+      (object) => {
+        const result = {} as { [K in keyof T]: Input<T[K]> }
+
+        for (const key in object) {
+          if (hasOwnProperty(object, key)) {
+            const codec = props[key]
+            result[key] = codec.encode(object[key])
+          }
+        }
+
+        return result
       }
-
-      ctx.setPath(path)
-
-      return ok ? ctx.success(object) : ctx.failures()
-    })
+    )
   }
 }
 
-export const object = <T extends Record<string, Codec<unknown>>>(
+export const object = <T extends Record<string, Codec<any>>>(
   props: T
 ): ObjectCodec<T> => new ObjectCodec(props)

--- a/src/codecs/optional.ts
+++ b/src/codecs/optional.ts
@@ -1,16 +1,18 @@
 import { Codec, Input, Output } from "../Codec.js"
 
-class OptionalCodec<C extends Codec<unknown>> extends Codec<
+class OptionalCodec<C extends Codec<any>> extends Codec<
   Input<C> | undefined,
   Output<C> | undefined
 > {
   readonly tag = "optional"
   constructor(readonly type: C) {
-    super((value, ctx) =>
-      value === undefined ? ctx.success(value) : type.validate(value, ctx)
+    super(
+      (value, ctx) =>
+        value === undefined ? ctx.success(value) : type.validate(value, ctx),
+      (value) => (value === undefined ? value : type.encode(value))
     )
   }
 }
 
-export const optional = <C extends Codec<unknown>>(type: C) =>
+export const optional = <C extends Codec<any>>(type: C) =>
   new OptionalCodec(type)

--- a/src/codecs/record.ts
+++ b/src/codecs/record.ts
@@ -2,48 +2,66 @@ import { Codec, Input, Output } from "../Codec.js"
 import { Success } from "../Result.js"
 import { hasOwnProperty } from "../utils.js"
 
-class RecordCodec<
-  K extends Codec<string>,
-  V extends Codec<unknown>
-> extends Codec<Record<Input<K>, Input<V>>, Record<Output<K>, Output<V>>> {
+class RecordCodec<K extends Codec<string>, V extends Codec<any>> extends Codec<
+  Record<Input<K>, Input<V>>,
+  Record<Output<K>, Output<V>>
+> {
   readonly tag = "record"
 
   constructor(readonly keys: K, readonly values: V) {
-    super((record, ctx) => {
-      if (record == null || typeof record !== "object" || Array.isArray(record))
-        return ctx.failure({
-          code: "invalid_type",
-          message: "Expected value to be an object",
-          value: record,
-        })
+    super(
+      (record, ctx) => {
+        if (
+          record == null ||
+          typeof record !== "object" ||
+          Array.isArray(record)
+        )
+          return ctx.failure({
+            code: "invalid_type",
+            message: "Expected value to be an object",
+            value: record,
+          })
 
-      const result = {} as Record<Output<K>, Output<V>>
-      let ok = true
-      const path = ctx.path
+        const result = {} as Record<Output<K>, Output<V>>
+        let ok = true
+        const path = ctx.path
 
-      for (const k in record) {
-        if (hasOwnProperty(record, k)) {
-          ctx.setPath(path ? `${path}.${k}` : k)
+        for (const k in record) {
+          if (hasOwnProperty(record, k)) {
+            ctx.setPath(path ? `${path}.${k}` : k)
 
-          const keyResult = keys.validate(k, ctx)
-          if (!keyResult.ok) ok = false
+            const keyResult = keys.validate(k, ctx)
+            if (!keyResult.ok) ok = false
 
-          const valueResult = values.validate(record[k], ctx)
-          if (!valueResult.ok) ok = false
-          else if (ok && valueResult.value !== undefined) {
-            result[(keyResult as Success<Output<K>>).value] = valueResult.value
+            const valueResult = values.validate(record[k], ctx)
+            if (!valueResult.ok) ok = false
+            else if (ok && valueResult.value !== undefined) {
+              result[(keyResult as Success<Output<K>>).value] =
+                valueResult.value
+            }
           }
         }
+
+        ctx.setPath(path)
+
+        return ok ? ctx.success(result) : ctx.failures()
+      },
+      (record) => {
+        const result = {} as Record<Input<K>, Input<V>>
+
+        for (const key in record) {
+          if (hasOwnProperty(record, key)) {
+            result[key as Input<K>] = values.encode(record[key as Input<K>])
+          }
+        }
+
+        return result
       }
-
-      ctx.setPath(path)
-
-      return ok ? ctx.success(result) : ctx.failures()
-    })
+    )
   }
 }
 
-export const record = <K extends Codec<string>, V extends Codec<unknown>>(
+export const record = <K extends Codec<string>, V extends Codec<any>>(
   keys: K,
   values: V
 ) => new RecordCodec(keys, values)

--- a/src/codecs/string.ts
+++ b/src/codecs/string.ts
@@ -1,6 +1,6 @@
-import { Codec } from "../Codec.js"
+import { SimpleCodec } from "../SimpleCodec.js"
 
-class StringCodec extends Codec<string> {
+class StringCodec extends SimpleCodec<string> {
   readonly tag = "string"
 
   constructor() {

--- a/src/codecs/union.ts
+++ b/src/codecs/union.ts
@@ -1,32 +1,20 @@
-import { Codec } from "../Codec.js"
 import { ValidationContext } from "../ValidationContext.js"
+import { SimpleCodec } from "../SimpleCodec.js"
 
 type UnionInputs<T extends readonly unknown[]> = T extends readonly [
-  Codec<infer I, unknown>,
+  SimpleCodec<infer I>,
   ...infer Rest
 ]
   ? I | UnionInputs<Rest>
   : T extends []
   ? never
-  : T extends readonly Codec<infer I, unknown>[]
+  : T extends readonly SimpleCodec<infer I>[]
   ? I
   : never
 
-type UnionOutputs<T extends readonly unknown[]> = T extends readonly [
-  Codec<unknown, infer O>,
-  ...infer Rest
-]
-  ? O | UnionOutputs<Rest>
-  : T extends []
-  ? never
-  : T extends readonly Codec<unknown, infer O>[]
-  ? O
-  : never
-
-class UnionCodec<C extends readonly Codec<unknown>[] | []> extends Codec<
-  UnionInputs<C>,
-  UnionOutputs<C>
-> {
+class UnionCodec<
+  C extends readonly SimpleCodec<any>[] | []
+> extends SimpleCodec<UnionInputs<C>> {
   constructor(readonly members: C) {
     super((value, ctx) => {
       const innerCtx = new ValidationContext(ctx.path)
@@ -34,8 +22,7 @@ class UnionCodec<C extends readonly Codec<unknown>[] | []> extends Codec<
       for (let i = 0; i < members.length; i++) {
         const codec = members[i]
         const result = codec.validate(value, innerCtx)
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        if (result.ok) return ctx.success(result.value) as any
+        if (result.ok) return ctx.success(result.value)
       }
 
       return ctx.failure({
@@ -48,6 +35,6 @@ class UnionCodec<C extends readonly Codec<unknown>[] | []> extends Codec<
   }
 }
 
-export const union = <C extends readonly Codec<unknown>[] | []>(
+export const union = <C extends readonly SimpleCodec<any>[] | []>(
   codecs: C
 ): UnionCodec<C> => new UnionCodec(codecs)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,3 +4,7 @@ export function hasOwnProperty<K extends string>(
 ): obj is Record<K, unknown> {
   return Object.prototype.hasOwnProperty.call(obj, key)
 }
+
+export function identity<T>(value: T) {
+  return value
+}


### PR DESCRIPTION
- Add an .encode method to Codec
- Introduce a new SimpleCodec subclass of Codec that signifies a codec
  that doesn't transform the parsed input value. In these kinds of
  codecs, the encode method is the identity function.
- Change the union codec to accept only simple codecs, so we don't have
  to check the type of the value at runtime.
